### PR TITLE
Update Avro to 1.8.0. All tests pass.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,7 +53,7 @@ object Build extends sbt.Build {
     sbtavro.SbtAvro.stringType in sbtavro.SbtAvro.avroConfig := "String",
     sourceDirectory in sbtavro.SbtAvro.avroConfig <<= (resourceDirectory in Test)(_ / "avsc"),
     javaSource in sbtavro.SbtAvro.avroConfig <<= (sourceManaged in Test)(_ / "java" / "compiled_avro"),
-    version in sbtavro.SbtAvro.avroConfig := "1.7.7",
+    version in sbtavro.SbtAvro.avroConfig := "1.8.0",
     sourceGenerators in Test <+= (sbtavro.SbtAvro.generate in sbtavro.SbtAvro.avroConfig),
     managedSourceDirectories in Test <+= (javaSource in sbtavro.SbtAvro.avroConfig))
 
@@ -145,7 +145,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-experimental" % AKKA_VERSION)
 
   val avro = Seq(
-    "org.apache.avro" % "avro" % "1.7.7")
+    "org.apache.avro" % "avro" % "1.8.0")
 
   val jackson = Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.3")
 


### PR DESCRIPTION
This is necessary as the dependency on snappy-java was at a version where the native code did not properly work under OSGi. Avro 1.8.0 uses a later version of snappy-java that does not have the issue.
